### PR TITLE
only apply selinux config if selinux is enabled

### DIFF
--- a/tasks/configure-RedHat.yml
+++ b/tasks/configure-RedHat.yml
@@ -7,6 +7,7 @@
     setype: squid_port_t
     reload: yes
     state: present
+  when: ansible_selinux.status == "enabled"
 
 - name: Configure SELinux policy (UDP)
   seport:
@@ -15,9 +16,11 @@
     setype: squid_port_t
     reload: yes
     state: present
+  when: ansible_selinux.status == "enabled"
 
 - name: Enable SELinux squid_connect_any
   seboolean:
     name: squid_connect_any
     state: "{{ squid_selinux_squid_connect_any }}"
     persistent: yes
+  when: ansible_selinux.status == "enabled"

--- a/tasks/configure-RedHat.yml
+++ b/tasks/configure-RedHat.yml
@@ -1,5 +1,13 @@
 ---
 
+# Run the setup module to gather facts again
+# just in case the SELinux tools were not
+# installed during the initial facts gathering
+# and variable {{ ansible_selinux }} was not defined
+
+- name: Gather facts about SELinux
+  setup:
+
 - name: Configure SELinux policy (TCP)
   seport:
     ports: "{{ squid_selinux_port_tcp | join(',') }}"


### PR DESCRIPTION
if you prefer I can update the PR use use a block like this:

```
---

- name: Only configure SElinux if it is enabled
  block:

    - name: Configure SELinux policy (TCP)
      seport:
        ports: "{{ squid_selinux_port_tcp | join(',') }}"
        proto: tcp
        setype: squid_port_t
        reload: yes
        state: present

    - name: Configure SELinux policy (UDP)
      seport:
        ports: "{{ squid_selinux_port_udp | join(',') }}"
        proto: udp
        setype: squid_port_t
        reload: yes
        state: present

    - name: Enable SELinux squid_connect_any
      seboolean:
        name: squid_connect_any
        state: "{{ squid_selinux_squid_connect_any }}"
        persistent: yes

  when: ansible_selinux.status == "enabled"
```